### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/client/collection.js
+++ b/lib/client/collection.js
@@ -1,6 +1,6 @@
 var Promise = require('bluebird');
 var _ = require('lodash');
-//var uuid = require('node-uuid').v4;
+//var uuid = require('uuid').v4;
 //var Kuery = require('kuery');
 var Cursor = require('./cursor');
 var EventEmitter = require('events').EventEmitter;

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 
 var ViewDbSocketServer = function(viewdb, socket) {
 	var _observers = {};

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "dependencies": {
     "bluebird": "^2.9.30",
-    "request-promise": "^0.4.3",
     "debug": "^2.2.0",
-    "kuery": "^0.2.0",
-    "lodash": "^4.8.2",
     "eslint": "^2.5.3",
     "eslint-config-surikat": "^1.1.0",
-    "node-uuid": "^1.4.3"
+    "kuery": "^0.2.0",
+    "lodash": "^4.8.2",
+    "request-promise": "^0.4.3",
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.