### PR TITLE
Feature/viewdb cache

### DIFF
--- a/lib/cacheUtils.js
+++ b/lib/cacheUtils.js
@@ -2,6 +2,6 @@ var SHA256 = require("crypto-js/sha256");
 
 exports.generateQueryHash = function (query, collection, skip, limit, sort) {
   return SHA256(
-    `${collection}:${skip}:${limit}:${JSON.stringify(sort)}:${JSON.stringify(query)}`
+    `${collection}:${skip||0}:${limit||''}:${JSON.stringify(sort||{})}:${JSON.stringify(query)}`
   ).toString();
 };

--- a/lib/cacheUtils.js
+++ b/lib/cacheUtils.js
@@ -1,7 +1,7 @@
 var SHA256 = require("crypto-js/sha256");
 
-exports.generateQueryHash = function (query, collection, skip, limit, sort) {
+exports.generateQueryHash = function (query, collection, skip, limit, sort, project) {
   return SHA256(
-    `${collection}:${skip||0}:${limit||''}:${JSON.stringify(sort||{})}:${JSON.stringify(query)}`
+    `${collection}:${skip||0}:${limit||0}:${JSON.stringify(sort||{})}:${JSON.stringify(project||{})}:${JSON.stringify(query)}`
   ).toString();
 };

--- a/lib/cacheUtils.js
+++ b/lib/cacheUtils.js
@@ -1,0 +1,7 @@
+var SHA256 = require("crypto-js/sha256");
+
+exports.generateQueryHash = function (query, collection, skip, limit, sort) {
+  return SHA256(
+    `${collection}:${skip}:${limit}:${JSON.stringify(sort)}:${JSON.stringify(query)}`
+  ).toString();
+};

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -2,12 +2,13 @@ var _ = require('lodash');
 var HybridCursor = require('./cursor');
 var cacheUtils = require('../cacheUtils');
 
-var HybridCollection = function (local, remote, name, options, cacheCollection) {
+var HybridCollection = function (local, remote, name, options, cacheCollection, projectedDocumentCollection) {
 	this._local = local;
 	this._remote = remote;
 	this._name = name;
 	this._options = options;
 	this._cacheCollection = cacheCollection;
+  this._projectedDocumentCollection = projectedDocumentCollection;
 };
 
 HybridCollection.prototype.find = function(query, options) {
@@ -51,8 +52,9 @@ HybridCollection.prototype.remove = function(query, options, callback) {
 	});
 };
 
-HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, documents) {
+HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, project, documents) {
   var self = this;
+  console.log('going to cache');
 
   if (!this._options.cacheQueries) {
     return;
@@ -62,14 +64,21 @@ HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, doc
   var documentIds = [];
   _.forEach(documents, function (document) {
     documentIds.push(document._id);
-    self._local.save(Object.assign({}, document, { _insertedAt: cachedDateTime }), { skipVersioning: true, skipTimestamp: true });
+
+    var isProjected = !_.isEmpty(project);
+    var collection = self._local;
+    if (isProjected) {
+      collection = self._projectedDocumentCollection;
+    }
+
+    collection.save(Object.assign({}, document, { _insertedAt: cachedDateTime }), { skipVersioning: true, skipTimestamp: true });
   });
 
-  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit, sort);
+  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit, sort, project);
   this._cacheCollection.save({ _id: queryHash, createDateTime: cachedDateTime, resultSet: documentIds }, { skipVersioning: true, skipTimestamp: true });
 };
 
-HybridCollection.prototype._getCachedData = function (query, skip, limit, sort, callback) {
+HybridCollection.prototype._getCachedData = function (query, skip, limit, sort, project, callback) {
   var self = this;
   this._getCachedIds(query, skip, limit, sort, function (ids) {
     if (!ids) {
@@ -77,7 +86,13 @@ HybridCollection.prototype._getCachedData = function (query, skip, limit, sort, 
       return;
     }
 
-    self._local
+    var collection = self._local;
+    var isProjected = !_.isEmpty(project);
+    if (isProjected) {
+      collection = self._projectedDocumentCollection;
+    }
+
+    collection
       .find({ _id: { $in: ids } })
       .toArray(function (cacheError, cachedResults) {
         if (cacheError) {

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -1,17 +1,25 @@
 var _ = require('lodash');
-
 var HybridCursor = require('./cursor');
+var cacheUtils = require('../cacheUtils');
 
-
-var HybridCollection = function(local, remote, name, options) {
+var HybridCollection = function (local, remote, name, options, cacheCollection) {
 	this._local = local;
 	this._remote = remote;
 	this._name = name;
 	this._options = options;
-}
+	this._cacheCollection = cacheCollection;
+};
 
 HybridCollection.prototype.find = function(query, options) {
-	return new HybridCursor(query, this._local.find(query, options), this._remote.find(query, options), options, this._options);
+	return new HybridCursor(
+    query,
+    this._local.find(query, options),
+    this._remote.find(query, options),
+		options,
+    this._options,
+    this._cacheQuery.bind(this),
+    this._cacheCollection
+  );
 };
 
 HybridCollection.prototype.save = function(doc, callback) {
@@ -44,5 +52,30 @@ HybridCollection.prototype.remove = function(query, options, callback) {
 		}
 	});
 }
+
+HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, documents) {
+  var self = this;
+
+  if (!this._options.cacheQueries) {
+    return;
+  }
+
+  var cachedDateTime = new Date().getTime();
+  var documentIds = [];
+  _.forEach(documents, function (document) {
+    documentIds.push(document._id);
+    self._local.save(Object.assign({}, document, { _insertedAt: cachedDateTime }), { skipVersioning: true, skipTimestamp: true });
+  });
+
+  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit, sort);
+  this._cacheCollection.save({
+    _id: queryHash,
+    createDateTime: cachedDateTime,
+    resultSet: documentIds,
+    // TODO: Remove properties below, only for testing
+    query: query,
+    collection: this._name
+  }, { skipVersioning: true, skipTimestamp: true });
+};
 
 module.exports = HybridCollection;

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -18,7 +18,7 @@ HybridCollection.prototype.find = function(query, options) {
 		options,
     this._options,
     this._cacheQuery.bind(this),
-    this._cacheCollection
+    this._getCachedData.bind(this)
   );
 };
 
@@ -67,7 +67,7 @@ HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, doc
     self._local.save(Object.assign({}, document, { _insertedAt: cachedDateTime }), { skipVersioning: true, skipTimestamp: true });
   });
 
-  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit, sort);
+  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit || '', sort);
   this._cacheCollection.save({
     _id: queryHash,
     createDateTime: cachedDateTime,
@@ -76,6 +76,48 @@ HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, doc
     query: query,
     collection: this._name
   }, { skipVersioning: true, skipTimestamp: true });
+};
+
+HybridCollection.prototype._getCachedData = function (query, skip, limit, sort, callback) {
+  var self = this;
+  this._getCachedIds(query, skip, limit, sort, function (ids) {
+    if (!ids) {
+      callback(undefined);
+      return;
+    }
+
+    self._local.find({ _id: { $in: ids } }).toArray(function (cacheError, cachedResults) {
+      if (cacheError) {
+        callback(cacheError, cachedResults);
+      }
+
+      callback(null, cachedResults);
+    });
+  });
+};
+
+HybridCollection.prototype._getCachedIds = function (query, skip, limit, sort, callback) {
+  if (!this._cacheCollection || !this._options.cacheLifeTime) {
+    callback(undefined);
+    return;
+  }
+
+  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit || '', sort);
+  var minimumChangeDateTime = new Date();
+  minimumChangeDateTime.setMinutes(
+    minimumChangeDateTime.getMinutes() - this._options.cacheLifeTime
+  );
+  var maxTimeEpoch = minimumChangeDateTime.getTime();
+
+  this._cacheCollection.find({ _id: queryHash, createDateTime: { $gt: maxTimeEpoch } }).toArray(function (err, result) {
+    var hasResult = result && result[0];
+
+    if (!hasResult) {
+      callback(undefined);
+      return;
+    }
+    callback(result[0].resultSet);
+  });
 };
 
 module.exports = HybridCollection;

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -67,7 +67,7 @@ HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, doc
     self._local.save(Object.assign({}, document, { _insertedAt: cachedDateTime }), { skipVersioning: true, skipTimestamp: true });
   });
 
-  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit || '', sort);
+  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit, sort);
   this._cacheCollection.save({ _id: queryHash, createDateTime: cachedDateTime, resultSet: documentIds }, { skipVersioning: true, skipTimestamp: true });
 };
 
@@ -97,15 +97,15 @@ HybridCollection.prototype._getCachedIds = function (query, skip, limit, sort, c
     return;
   }
 
-  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit || '', sort);
+  var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit, sort);
   var minimumChangeDateTime = new Date();
   minimumChangeDateTime.setMinutes(
     minimumChangeDateTime.getMinutes() - this._options.cacheLifeTime
   );
-  var maxTimeEpoch = minimumChangeDateTime.getTime();
+  var minTimeEpoch = minimumChangeDateTime.getTime();
 
   this._cacheCollection
-    .find({ _id: queryHash, createDateTime: { $gt: maxTimeEpoch } })
+    .find({ _id: queryHash, createDateTime: { $gt: minTimeEpoch } })
     .toArray(function (err, result) {
       var hasResult = result && result[0];
 

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -54,7 +54,6 @@ HybridCollection.prototype.remove = function(query, options, callback) {
 
 HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, project, documents) {
   var self = this;
-  console.log('going to cache');
 
   if (!this._options.cacheQueries) {
     return;

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -27,7 +27,7 @@ HybridCollection.prototype.save = function(doc, callback) {
 		this._remote.save(doc, callback);
 	}
 	return this._local.save(doc, callback);
-}
+};
 
 HybridCollection.prototype.insert = function(doc, callback) {
 	var self = this;
@@ -39,7 +39,7 @@ HybridCollection.prototype.insert = function(doc, callback) {
 			callback(err, result);
 		}
 	});
-}
+};
 
 HybridCollection.prototype.remove = function(query, options, callback) {
 	var self = this;
@@ -51,7 +51,7 @@ HybridCollection.prototype.remove = function(query, options, callback) {
 			callback(err, result);
 		}
 	});
-}
+};
 
 HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, documents) {
   var self = this;
@@ -68,14 +68,7 @@ HybridCollection.prototype._cacheQuery = function (query, skip, limit, sort, doc
   });
 
   var queryHash = cacheUtils.generateQueryHash(query, this._name, skip, limit || '', sort);
-  this._cacheCollection.save({
-    _id: queryHash,
-    createDateTime: cachedDateTime,
-    resultSet: documentIds,
-    // TODO: Remove properties below, only for testing
-    query: query,
-    collection: this._name
-  }, { skipVersioning: true, skipTimestamp: true });
+  this._cacheCollection.save({ _id: queryHash, createDateTime: cachedDateTime, resultSet: documentIds }, { skipVersioning: true, skipTimestamp: true });
 };
 
 HybridCollection.prototype._getCachedData = function (query, skip, limit, sort, callback) {
@@ -86,13 +79,15 @@ HybridCollection.prototype._getCachedData = function (query, skip, limit, sort, 
       return;
     }
 
-    self._local.find({ _id: { $in: ids } }).toArray(function (cacheError, cachedResults) {
-      if (cacheError) {
-        callback(cacheError, cachedResults);
-      }
+    self._local
+      .find({ _id: { $in: ids } })
+      .toArray(function (cacheError, cachedResults) {
+        if (cacheError) {
+          callback(cacheError, cachedResults);
+        }
 
-      callback(null, cachedResults);
-    });
+        callback(null, cachedResults);
+      });
   });
 };
 
@@ -109,15 +104,17 @@ HybridCollection.prototype._getCachedIds = function (query, skip, limit, sort, c
   );
   var maxTimeEpoch = minimumChangeDateTime.getTime();
 
-  this._cacheCollection.find({ _id: queryHash, createDateTime: { $gt: maxTimeEpoch } }).toArray(function (err, result) {
-    var hasResult = result && result[0];
+  this._cacheCollection
+    .find({ _id: queryHash, createDateTime: { $gt: maxTimeEpoch } })
+    .toArray(function (err, result) {
+      var hasResult = result && result[0];
 
-    if (!hasResult) {
-      callback(undefined);
-      return;
-    }
-    callback(result[0].resultSet);
-  });
+      if (!hasResult) {
+        callback(undefined);
+        return;
+      }
+      callback(result[0].resultSet);
+    });
 };
 
 module.exports = HybridCollection;

--- a/lib/hybrid/collection.js
+++ b/lib/hybrid/collection.js
@@ -16,9 +16,7 @@ HybridCollection.prototype.find = function(query, options) {
     this._local.find(query, options),
     this._remote.find(query, options),
 		options,
-    this._options,
-    this._cacheQuery.bind(this),
-    this._getCachedData.bind(this)
+    Object.assign({}, this._options, { onCacheUpdateCallback: this._cacheQuery.bind(this), getCachedData: this._getCachedData.bind(this) })
   );
 };
 

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -33,7 +33,8 @@ HybridCursor.prototype._toArray = function (callback) {
   var kuery = new Kuery(this._query);
   var sort = this._sort;
   var limit = this._limit;
-  var skip = 0;
+  var skip = this._skip;
+  var project = this._project;
 
   if (sort) {
     kuery.sort(sort);
@@ -55,7 +56,7 @@ HybridCursor.prototype._toArray = function (callback) {
       var combinedResult = kuery.find(reconcile(localData, remoteData));
       callback(null, combinedResult);
       if (_.isFunction(self._onCacheUpdateCallback)) {
-        self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
+        self._onCacheUpdateCallback(self._query, skip, limit, sort, project, combinedResult);
       }
     }
   }
@@ -72,7 +73,7 @@ HybridCursor.prototype._toArray = function (callback) {
         var combinedResult = kuery.find(reconcile(localData, remoteData || []));
         callback(null, combinedResult);
         if (_.isFunction(self._onCacheUpdateCallback)) {
-          self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
+          self._onCacheUpdateCallback(self._query, skip, limit, sort, project, combinedResult);
         }
       }
     } else {
@@ -90,8 +91,8 @@ HybridCursor.prototype._toArray = function (callback) {
     this._local.limit(limit);
     this._remote.limit(limit);
   }
-  if (this._project) {
-    this._remote.project(this._project);
+  if (project) {
+    this._remote.project(project);
   }
 
   this._local.toArray(localResult);
@@ -102,8 +103,8 @@ HybridCursor.prototype.toArray = function (callback) {
   var self = this;
 
   if (this._getCachedData) {
-    this._getCachedData(this._query, this._skip, this._limit, this._sort, function(err, data) {
-      if (data) {
+    this._getCachedData(this._query, this._skip, this._limit, this._sort, this._project, function (err, data) {
+      if (data && data.length > 0) {
         callback(null, data);
         return;
       }
@@ -144,7 +145,7 @@ HybridCursor.prototype.updateQuery = function (query) {
 
 HybridCursor.prototype._onObserverCacheUpdate = function (result) {
   if (_.isFunction(this._onCacheUpdateCallback)) {
-    this._onCacheUpdateCallback(this._query, this._skip, this._limit, this._sort, result);
+    this._onCacheUpdateCallback(this._query, this._skip, this._limit, this._sort, this._project, result);
   }
 };
 
@@ -162,6 +163,7 @@ HybridCursor.prototype.observe = function (options) {
 
 HybridCursor.prototype.project = function (project) {
   this._project = project;
+  return this;
 };
 
 module.exports = HybridCursor;

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -71,6 +71,9 @@ HybridCursor.prototype.toArray = function (callback) {
     this._local.limit(limit);
     this._remote.limit(limit);
   }
+  if (this._project) {
+    this._remote.project(this._project);
+  }
 
   this._local.toArray(localResult);
   this._remote.toArray(serverResult);
@@ -105,6 +108,10 @@ HybridCursor.prototype.updateQuery = function (query) {
 
 HybridCursor.prototype.observe = function (options) {
   return new Observe(this._local, this._remote, this._options, options);
-}
+};
+
+HybridCursor.prototype.project = function (project) {
+  this._project = project;
+};
 
 module.exports = HybridCursor;

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -1,9 +1,19 @@
 var Kuery = require('kuery');
-
 var Observe = require('./observe');
-
 var reconcile = require('./reconcile');
-var HybridCursor = function (query, local, remote, findOptions, options) {
+var cacheUtils = require('../cacheUtils');
+
+/**
+ *
+ * @param {*} query Mongodb query, for example: { 'identifiers.identifier': 'abc' }
+ * @param {*} local Local cursor
+ * @param {*} remote Remote cursor
+ * @param {*} findOptions Not in use?
+ * @param {*} options Options supplied from collection.
+ * @param {*} onCacheUpdateCallback Optional callback used when data is fetched from remote and should be stored.
+ * @param {*} cacheCollection Optional collection were cached data is stored.
+ */
+var HybridCursor = function (query, local, remote, findOptions, options, onCacheUpdateCallback, cacheCollection) {
   this._query = query;
   this._sort = null;
   this._limit = null;
@@ -11,9 +21,11 @@ var HybridCursor = function (query, local, remote, findOptions, options) {
   this._remote = remote;
   this._findOptions = findOptions;
   this._options = options;
-}
+  this._onCacheUpdateCallback = onCacheUpdateCallback;
+  this._cacheCollection = cacheCollection;
+};
 
-HybridCursor.prototype.toArray = function (callback) {
+HybridCursor.prototype._toArray = function (callback) {
   //reconcile strategy
   var self = this;
   var localData = null;
@@ -41,7 +53,9 @@ HybridCursor.prototype.toArray = function (callback) {
     }
     remoteData = result;
     if (localData) {
-      callback(null, kuery.find(reconcile(localData, remoteData)));
+      var combinedResult = kuery.find(reconcile(localData, remoteData));
+      callback(null, combinedResult);
+      self._onCacheUpdateCallback(self._query, '', limit, sort || '', combinedResult);
     }
   }
 
@@ -54,7 +68,9 @@ HybridCursor.prototype.toArray = function (callback) {
     localData = result;
     if (remoteData || remoteErr) {
       if (!(remoteErr && self._options.throwRemoteErr)) {
-        callback(null, kuery.find(reconcile(localData, remoteData || [])));
+        var combinedResult = kuery.find(reconcile(localData, remoteData || []));
+        callback(null, combinedResult);
+        self._onCacheUpdateCallback(self._query, '', limit, sort || '', combinedResult);
       }
     } else {
       if (self._options.localFirst) {
@@ -74,6 +90,30 @@ HybridCursor.prototype.toArray = function (callback) {
 
   this._local.toArray(localResult);
   this._remote.toArray(serverResult);
+};
+
+HybridCursor.prototype.toArray = function (callback) {
+  var self = this;
+
+  if (this._cacheCollection) {
+    this._getCachedIds(function (ids) {
+      if (ids) {
+        self.local._query.query = { _id: { $in: ids } };
+        self.local._refresh();
+        self.local.toArray(function (cacheError, cachedResults) {
+          if (cacheError) {
+            callback(cacheError, cachedResults);
+          }
+
+          callback(null, cachedResults);
+        });
+      } else {
+        self._toArray(callback);
+      }
+    });
+  } else {
+    this._toArray(callback);
+  }
 };
 
 HybridCursor.prototype._refresh = function () {
@@ -103,8 +143,20 @@ HybridCursor.prototype.updateQuery = function (query) {
   this._refresh();
 };
 
+HybridCursor.prototype._getCachedIds = function (callback) {
+  var queryHash = cacheUtils.generateQueryHash(this._query, '', this._skip, this._limit | '', this._sort);
+  this._cacheCollection.find({ _id: queryHash }).toArray(function (err, result) {
+    var hasResult = result && result[0];
+    callback(hasResult);
+  });
+};
+
+HybridCursor.prototype._onObserverCacheUpdate = function (result) {
+  this._onCacheUpdateCallback(this._query, '', this._limit, this._sort || '', result);
+};
+
 HybridCursor.prototype.observe = function (options) {
-  return new Observe(this._local, this._remote, this._options, options);
-}
+  return new Observe(this._local, this._remote, this._options, options, this._onObserverCacheUpdate.bind(this));
+};
 
 module.exports = HybridCursor;

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -154,7 +154,7 @@ HybridCursor.prototype._getObserverData = function (callback) {
 };
 
 HybridCursor.prototype.observe = function (options) {
-  if (this._project) {
+  if (this._project && _.isFunction(this._remote.project)) {
     this._remote.project(this._project);
   }
 

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -1,7 +1,6 @@
 var Kuery = require('kuery');
 var Observe = require('./observe');
 var reconcile = require('./reconcile');
-var cacheUtils = require('../cacheUtils');
 
 /**
  *
@@ -141,7 +140,7 @@ HybridCursor.prototype._onObserverCacheUpdate = function (result) {
 };
 
 HybridCursor.prototype._getObserverData = function (callback) {
-  this._getCachedData(this._query, this._skip || '', this._limit, this._sort || '', callback)
+  this._getCachedData(this._query, this._skip || '', this._limit, this._sort || '', callback);
 };
 
 HybridCursor.prototype.observe = function (options) {

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -107,6 +107,10 @@ HybridCursor.prototype.updateQuery = function (query) {
 };
 
 HybridCursor.prototype.observe = function (options) {
+  if (this._project) {
+    this._remote.project(this._project);
+  }
+
   return new Observe(this._local, this._remote, this._options, options);
 };
 

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -34,6 +34,7 @@ HybridCursor.prototype._toArray = function (callback) {
   var kuery = new Kuery(this._query);
   var sort = this._sort;
   var limit = this._limit;
+  var skip = 0;
 
   if (sort) {
     kuery.sort(sort);
@@ -54,7 +55,7 @@ HybridCursor.prototype._toArray = function (callback) {
     if (localData) {
       var combinedResult = kuery.find(reconcile(localData, remoteData));
       callback(null, combinedResult);
-      self._onCacheUpdateCallback(self._query, '', limit, sort || '', combinedResult);
+      self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
     }
   }
 
@@ -69,7 +70,7 @@ HybridCursor.prototype._toArray = function (callback) {
       if (!(remoteErr && self._options.throwRemoteErr)) {
         var combinedResult = kuery.find(reconcile(localData, remoteData || []));
         callback(null, combinedResult);
-        self._onCacheUpdateCallback(self._query, '', limit, sort || '', combinedResult);
+        self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
       }
     } else {
       if (self._options.localFirst) {
@@ -95,7 +96,7 @@ HybridCursor.prototype.toArray = function (callback) {
   var self = this;
 
   if (this._getCachedData) {
-    this._getCachedData(this._query, this._skip || '', this._limit, this._sort || '', function(err, data) {
+    this._getCachedData(this._query, this._skip, this._limit, this._sort, function(err, data) {
       if (data) {
         callback(null, data);
         return;
@@ -136,11 +137,11 @@ HybridCursor.prototype.updateQuery = function (query) {
 };
 
 HybridCursor.prototype._onObserverCacheUpdate = function (result) {
-  this._onCacheUpdateCallback(this._query, this._skip || '', this._limit, this._sort || '', result);
+  this._onCacheUpdateCallback(this._query, this._skip, this._limit, this._sort, result);
 };
 
 HybridCursor.prototype._getObserverData = function (callback) {
-  this._getCachedData(this._query, this._skip || '', this._limit, this._sort || '', callback);
+  this._getCachedData(this._query, this._skip, this._limit, this._sort, callback);
 };
 
 HybridCursor.prototype.observe = function (options) {

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -11,9 +11,9 @@ var cacheUtils = require('../cacheUtils');
  * @param {*} findOptions Not in use?
  * @param {*} options Options supplied from collection.
  * @param {*} onCacheUpdateCallback Optional callback used when data is fetched from remote and should be stored.
- * @param {*} cacheCollection Optional collection were cached data is stored.
+ * @param {*} getCachedData Optional getter to retrieve cached data based on query parameters
  */
-var HybridCursor = function (query, local, remote, findOptions, options, onCacheUpdateCallback, cacheCollection) {
+var HybridCursor = function (query, local, remote, findOptions, options, onCacheUpdateCallback, getCachedData) {
   this._query = query;
   this._sort = null;
   this._limit = null;
@@ -22,7 +22,7 @@ var HybridCursor = function (query, local, remote, findOptions, options, onCache
   this._findOptions = findOptions;
   this._options = options;
   this._onCacheUpdateCallback = onCacheUpdateCallback;
-  this._cacheCollection = cacheCollection;
+  this._getCachedData = getCachedData;
 };
 
 HybridCursor.prototype._toArray = function (callback) {
@@ -95,21 +95,14 @@ HybridCursor.prototype._toArray = function (callback) {
 HybridCursor.prototype.toArray = function (callback) {
   var self = this;
 
-  if (this._cacheCollection) {
-    this._getCachedIds(function (ids) {
-      if (ids) {
-        self.local._query.query = { _id: { $in: ids } };
-        self.local._refresh();
-        self.local.toArray(function (cacheError, cachedResults) {
-          if (cacheError) {
-            callback(cacheError, cachedResults);
-          }
-
-          callback(null, cachedResults);
-        });
-      } else {
-        self._toArray(callback);
+  if (this._getCachedData) {
+    this._getCachedData(this._query, this._skip || '', this._limit, this._sort || '', function(err, data) {
+      if (data) {
+        callback(null, data);
+        return;
       }
+
+      self._toArray(callback);
     });
   } else {
     this._toArray(callback);
@@ -143,33 +136,12 @@ HybridCursor.prototype.updateQuery = function (query) {
   this._refresh();
 };
 
-HybridCursor.prototype._getCachedIds = function (callback) {
-  if (!this._cacheCollection || !this._options.cacheLifeTime) {
-    callback(undefined);
-    return;
-  }
-
-  var queryHash = cacheUtils.generateQueryHash(this._query, '', this._skip, this._limit | '', this._sort);
-  var minimumChangeDateTime = new Date();
-  minimumChangeDateTime.setMinutes(
-    minimumChangeDateTime.getMinutes() - this._options.cacheLifeTime
-  );
-  var maxTimeEpoch = minimumChangeDateTime.getTime();
-
-  this._cacheCollection.find({ _id: queryHash, createDateTime: { $lt: maxTimeEpoch } }).toArray(function (err, result) {
-    var hasResult = result && result[0];
-
-    if (!hasResult) {
-      callback(undefined);
-      return;
-    }
-
-    callback(result[0]);
-  });
+HybridCursor.prototype._onObserverCacheUpdate = function (result) {
+  this._onCacheUpdateCallback(this._query, this._skip || '', this._limit, this._sort || '', result);
 };
 
-HybridCursor.prototype._onObserverCacheUpdate = function (result) {
-  this._onCacheUpdateCallback(this._query, '', this._limit, this._sort || '', result);
+HybridCursor.prototype._getObserverData = function (callback) {
+  this._getCachedData(this._query, this._skip || '', this._limit, this._sort || '', callback)
 };
 
 HybridCursor.prototype.observe = function (options) {

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -1,6 +1,7 @@
 var Kuery = require('kuery');
 var Observe = require('./observe');
 var reconcile = require('./reconcile');
+var _ = require('lodash');
 
 /**
  *
@@ -9,10 +10,8 @@ var reconcile = require('./reconcile');
  * @param {*} remote Remote cursor
  * @param {*} findOptions Not in use?
  * @param {*} options Options supplied from collection.
- * @param {*} onCacheUpdateCallback Optional callback used when data is fetched from remote and should be stored.
- * @param {*} getCachedData Optional getter to retrieve cached data based on query parameters
  */
-var HybridCursor = function (query, local, remote, findOptions, options, onCacheUpdateCallback, getCachedData) {
+var HybridCursor = function (query, local, remote, findOptions, options) {
   this._query = query;
   this._sort = null;
   this._limit = null;
@@ -20,8 +19,8 @@ var HybridCursor = function (query, local, remote, findOptions, options, onCache
   this._remote = remote;
   this._findOptions = findOptions;
   this._options = options;
-  this._onCacheUpdateCallback = onCacheUpdateCallback;
-  this._getCachedData = getCachedData;
+  this._onCacheUpdateCallback = options.onCacheUpdateCallback;
+  this._getCachedData = options.getCachedData;
 };
 
 HybridCursor.prototype._toArray = function (callback) {
@@ -55,7 +54,9 @@ HybridCursor.prototype._toArray = function (callback) {
     if (localData) {
       var combinedResult = kuery.find(reconcile(localData, remoteData));
       callback(null, combinedResult);
-      self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
+      if (_.isFunction(self._onCacheUpdateCallback)) {
+        self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
+      }
     }
   }
 
@@ -70,7 +71,9 @@ HybridCursor.prototype._toArray = function (callback) {
       if (!(remoteErr && self._options.throwRemoteErr)) {
         var combinedResult = kuery.find(reconcile(localData, remoteData || []));
         callback(null, combinedResult);
-        self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
+        if (_.isFunction(self._onCacheUpdateCallback)) {
+          self._onCacheUpdateCallback(self._query, skip, limit, sort, combinedResult);
+        }
       }
     } else {
       if (self._options.localFirst) {
@@ -137,7 +140,9 @@ HybridCursor.prototype.updateQuery = function (query) {
 };
 
 HybridCursor.prototype._onObserverCacheUpdate = function (result) {
-  this._onCacheUpdateCallback(this._query, this._skip, this._limit, this._sort, result);
+  if (_.isFunction(this._onCacheUpdateCallback)) {
+    this._onCacheUpdateCallback(this._query, this._skip, this._limit, this._sort, result);
+  }
 };
 
 HybridCursor.prototype._getObserverData = function (callback) {

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -145,7 +145,7 @@ HybridCursor.prototype._getObserverData = function (callback) {
 };
 
 HybridCursor.prototype.observe = function (options) {
-  return new Observe(this._local, this._remote, this._options, options, this._onObserverCacheUpdate.bind(this));
+  return new Observe(this._local, this._remote, this._options, options, this._onObserverCacheUpdate.bind(this), this._getObserverData.bind(this));
 };
 
 module.exports = HybridCursor;

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -91,7 +91,7 @@ HybridCursor.prototype._toArray = function (callback) {
     this._local.limit(limit);
     this._remote.limit(limit);
   }
-  if (project) {
+  if (project && _.isFunction(this._remote.project)) {
     this._remote.project(project);
   }
 

--- a/lib/hybrid/cursor.js
+++ b/lib/hybrid/cursor.js
@@ -144,10 +144,27 @@ HybridCursor.prototype.updateQuery = function (query) {
 };
 
 HybridCursor.prototype._getCachedIds = function (callback) {
+  if (!this._cacheCollection || !this._options.cacheLifeTime) {
+    callback(undefined);
+    return;
+  }
+
   var queryHash = cacheUtils.generateQueryHash(this._query, '', this._skip, this._limit | '', this._sort);
-  this._cacheCollection.find({ _id: queryHash }).toArray(function (err, result) {
+  var minimumChangeDateTime = new Date();
+  minimumChangeDateTime.setMinutes(
+    minimumChangeDateTime.getMinutes() - this._options.cacheLifeTime
+  );
+  var maxTimeEpoch = minimumChangeDateTime.getTime();
+
+  this._cacheCollection.find({ _id: queryHash, createDateTime: { $lt: maxTimeEpoch } }).toArray(function (err, result) {
     var hasResult = result && result[0];
-    callback(hasResult);
+
+    if (!hasResult) {
+      callback(undefined);
+      return;
+    }
+
+    callback(result[0]);
   });
 };
 

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -5,7 +5,7 @@ function pushArray(arr, arr2) {
   arr.push.apply(arr, arr2);
 }
 
-function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
+function buildOptions(cache, callback, removed, isRemote) {
   return {
     init: function (result) {
       // console.log('init', result, cache)
@@ -16,9 +16,6 @@ function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
         cache.length = 0;
         pushArray(cache, result);
       }
-      if (isRemote && _.isFunction(onRemoteChange)) {
-        onRemoteChange();
-      }
       callback(result);
     },
     added: function (e, index) {
@@ -26,9 +23,6 @@ function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
       cache.splice(index, 0, e);
       if (isRemote && removed.length > 0) {
         removed = [];
-      }
-      if (isRemote && _.isFunction(onRemoteChange)) {
-        onRemoteChange();
       }
       callback(e);
     },
@@ -42,9 +36,6 @@ function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
       if (isRemote && removed.length > 0) {
         removed = [];
       }
-      if (isRemote && _.isFunction(onRemoteChange)) {
-        onRemoteChange();
-      }
       callback(e);
     },
     changed: function (asis, tobe, index) {
@@ -52,9 +43,6 @@ function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
       cache[index] = tobe;
       if (isRemote && removed.length > 0) {
         removed = [];
-      }
-      if (isRemote && _.isFunction(onRemoteChange)) {
-        onRemoteChange();
       }
       callback(tobe);
     },
@@ -66,9 +54,6 @@ function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
       cache.splice(newIndex, 0, e);
       if (isRemote && removed.length > 0) {
         removed = [];
-      }
-      if (isRemote && _.isFunction(onRemoteChange)) {
-        onRemoteChange();
       }
       callback(e);
     }
@@ -91,17 +76,17 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
   this._remoteCursor = remoteCursor;
   this._options = options;
   this._cacheCallback = cacheCallback;
+  this._getCache = getCache;
 
   this._localCache = [];
   this._remoteCache = [];
   this._removed = [];
   this._reconciledCache = [];
-  this._remoteHasChanged = false;
 
   // make sure refresh is only called once every x ms
   var _refresh = _.throttle(this.refresh.bind(this), collectionOptions.throttleObserveRefresh);
 
-  var remoteOptions = buildOptions(this._remoteCache, _refresh, this._removed, true, this._onRemoteChange.bind(this));
+  var remoteOptions = buildOptions(this._remoteCache, _refresh, this._removed, true);
   if (!getCache) {
     this._localHandle = this._localCursor.observe(buildOptions(this._localCache, _refresh, this._removed, false));
     this._remoteHandle = this._remoteCursor.observe(remoteOptions);
@@ -135,10 +120,6 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
   };
 };
 
-HybridObserver.prototype._onRemoteChange = function () {
-  this._remoteHasChanged = true;
-};
-
 HybridObserver.prototype.refresh = function () {
   var self = this;
   // console.log('refresh');
@@ -166,9 +147,8 @@ HybridObserver.prototype.refresh = function () {
     }, self._options));
   }
 
-  if (this._cacheCallback && this._remoteHasChanged) {
-    this._cacheCallback(this._reconciledCache);
-    this._remoteHasChanged = false;
+  if (this._cacheCallback && this._getCache) {
+    this._cacheCallback(remoteCache);
   }
 };
 

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -109,7 +109,7 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
   } else {
     getCache(function (err, data) {
       if (data) {
-        self._remoteCache = data;
+        self._remoteCache.concat(data);
         delete remoteOptions.init;
       }
       self._remoteHandle = self._remoteCursor.observe(remoteOptions);

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -5,7 +5,7 @@ function pushArray(arr, arr2) {
   arr.push.apply(arr, arr2);
 }
 
-function buildOptions(cache, callback, removed, isRemote) {
+function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
   return {
     init: function (result) {
       // console.log('init', result, cache)
@@ -16,6 +16,9 @@ function buildOptions(cache, callback, removed, isRemote) {
         cache.length = 0;
         pushArray(cache, result);
       }
+      if (isRemote && _.isFunction(onRemoteChange)) {
+        onRemoteChange();
+      }
       callback(result);
     },
     added: function (e, index) {
@@ -23,6 +26,9 @@ function buildOptions(cache, callback, removed, isRemote) {
       cache.splice(index, 0, e);
       if (isRemote && removed.length > 0) {
         removed = [];
+      }
+      if (isRemote && _.isFunction(onRemoteChange)) {
+        onRemoteChange();
       }
       callback(e);
     },
@@ -36,7 +42,9 @@ function buildOptions(cache, callback, removed, isRemote) {
       if (isRemote && removed.length > 0) {
         removed = [];
       }
-
+      if (isRemote && _.isFunction(onRemoteChange)) {
+        onRemoteChange();
+      }
       callback(e);
     },
     changed: function (asis, tobe, index) {
@@ -44,6 +52,9 @@ function buildOptions(cache, callback, removed, isRemote) {
       cache[index] = tobe;
       if (isRemote && removed.length > 0) {
         removed = [];
+      }
+      if (isRemote && _.isFunction(onRemoteChange)) {
+        onRemoteChange();
       }
       callback(tobe);
     },
@@ -56,29 +67,44 @@ function buildOptions(cache, callback, removed, isRemote) {
       if (isRemote && removed.length > 0) {
         removed = [];
       }
+      if (isRemote && _.isFunction(onRemoteChange)) {
+        onRemoteChange();
+      }
       callback(e);
     }
   }
 }
 
-var HybridObserver = function (localCursor, remoteCursor, collectionOptions, options) {
+/**
+ * @param {*} localCursor Local cursor
+ * @param {*} remoteCursor Remote cursor
+ * @param {object} collectionOptions Options supplied from collection
+ * @param {object} options Options to callback on data change
+ * @param {*} cacheCallback Callback for when cache should be updated
+ */
+var HybridObserver = function (localCursor, remoteCursor, collectionOptions, options, cacheCallback) {
   var self = this;
 
   this._initialized = false;
   this._localCursor = localCursor;
   this._remoteCursor = remoteCursor;
   this._options = options;
+  this._cacheCallback = cacheCallback;
 
   this._localCache = [];
   this._remoteCache = [];
   this._removed = [];
   this._reconciledCache = [];
+  this._remoteHasChanged = false;
 
   // make sure refresh is only called once every x ms
   var _refresh = _.throttle(this.refresh.bind(this), collectionOptions.throttleObserveRefresh);
 
   this._localHandle = this._localCursor.observe(buildOptions(this._localCache, _refresh, this._removed, false));
-  this._remoteHandle = this._remoteCursor.observe(buildOptions(this._remoteCache, _refresh, this._removed, true));
+
+  var remoteOptions = buildOptions(this._remoteCache, _refresh, this._removed, true, this._onRemoteChange.bind(this));
+  this._remoteHandle = this._remoteCursor.observe(remoteOptions);
+
   return {
     stop: function () {
       // Help garbage collection? :)
@@ -89,6 +115,10 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
       self._remoteHandle.stop();
     }
   };
+};
+
+HybridObserver.prototype._onRemoteChange = function () {
+  this._remoteHasChanged = true;
 };
 
 HybridObserver.prototype.refresh = function () {
@@ -117,6 +147,11 @@ HybridObserver.prototype.refresh = function () {
       }
     }, self._options));
   }
-}
+
+  if (this._cacheCallback && this._remoteHasChanged) {
+    this._cacheCallback(self._reconciledCache);
+    this._remoteHasChanged = false;
+  }
+};
 
 module.exports = HybridObserver;

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -81,8 +81,9 @@ function buildOptions(cache, callback, removed, isRemote, onRemoteChange) {
  * @param {object} collectionOptions Options supplied from collection
  * @param {object} options Options to callback on data change
  * @param {*} cacheCallback Callback for when cache should be updated
+ * @param {*} getCache Getter for retrieving data that is stored in local cache.
  */
-var HybridObserver = function (localCursor, remoteCursor, collectionOptions, options, cacheCallback) {
+var HybridObserver = function (localCursor, remoteCursor, collectionOptions, options, cacheCallback, getCache) {
   var self = this;
 
   this._initialized = false;
@@ -103,7 +104,17 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
   this._localHandle = this._localCursor.observe(buildOptions(this._localCache, _refresh, this._removed, false));
 
   var remoteOptions = buildOptions(this._remoteCache, _refresh, this._removed, true, this._onRemoteChange.bind(this));
-  this._remoteHandle = this._remoteCursor.observe(remoteOptions);
+  if (!getCache) {
+    this._remoteHandle = this._remoteCursor.observe(remoteOptions);
+  } else {
+    getCache(function (err, data) {
+      if (data) {
+        self._remoteCache = data;
+        delete remoteOptions.init;
+      }
+      self._remoteHandle = self._remoteCursor.observe(remoteOptions);
+    });
+  }
 
   return {
     stop: function () {

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -94,6 +94,7 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
     getCache(function (err, data) {
       if (data) {
         self._remoteCache.concat(data);
+        self.refresh();
         delete remoteOptions.init;
       }
       self._remoteHandle = self._remoteCursor.observe(remoteOptions);

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -101,10 +101,9 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
   // make sure refresh is only called once every x ms
   var _refresh = _.throttle(this.refresh.bind(this), collectionOptions.throttleObserveRefresh);
 
-  this._localHandle = this._localCursor.observe(buildOptions(this._localCache, _refresh, this._removed, false));
-
   var remoteOptions = buildOptions(this._remoteCache, _refresh, this._removed, true, this._onRemoteChange.bind(this));
   if (!getCache) {
+    this._localHandle = this._localCursor.observe(buildOptions(this._localCache, _refresh, this._removed, false));
     this._remoteHandle = this._remoteCursor.observe(remoteOptions);
   } else {
     getCache(function (err, data) {
@@ -114,6 +113,15 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
       }
       self._remoteHandle = self._remoteCursor.observe(remoteOptions);
     });
+
+    var cacheUpdater = function () {
+      self._cacheCallback(self._remoteCache);
+    };
+
+    console.log(this.options.cacheLifeTime);
+
+    // While the observer is running, keep the cached data alive
+    this._cacheUpdaterInterval = setInterval(cacheUpdater, 1000 * 60 * Math.max(this.options.cacheLifeTime / 2, 1));
   }
 
   return {
@@ -122,8 +130,9 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
       this._localCache = null;
       this._remoteCache = null;
       this._reconciledCache = null;
-      self._localHandle.stop();
+      self._localHandle && self._localHandle.stop();
       self._remoteHandle.stop();
+      clearInterval(self._cacheUpdaterInterval);
     }
   };
 };
@@ -160,7 +169,7 @@ HybridObserver.prototype.refresh = function () {
   }
 
   if (this._cacheCallback && this._remoteHasChanged) {
-    this._cacheCallback(self._reconciledCache);
+    this._cacheCallback(this._reconciledCache);
     this._remoteHasChanged = false;
   }
 };

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -118,10 +118,8 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
       self._cacheCallback(self._remoteCache);
     };
 
-    console.log(this.options.cacheLifeTime);
-
     // While the observer is running, keep the cached data alive
-    this._cacheUpdaterInterval = setInterval(cacheUpdater, 1000 * 60 * Math.max(this.options.cacheLifeTime / 2, 1));
+    this._cacheUpdaterInterval = setInterval(cacheUpdater, 1000 * 60 * Math.max(collectionOptions.cacheLifeTime / 2, 1));
   }
 
   return {

--- a/lib/hybrid/observe.js
+++ b/lib/hybrid/observe.js
@@ -65,18 +65,16 @@ function buildOptions(cache, callback, removed, isRemote) {
  * @param {*} remoteCursor Remote cursor
  * @param {object} collectionOptions Options supplied from collection
  * @param {object} options Options to callback on data change
- * @param {*} cacheCallback Callback for when cache should be updated
- * @param {*} getCache Getter for retrieving data that is stored in local cache.
  */
-var HybridObserver = function (localCursor, remoteCursor, collectionOptions, options, cacheCallback, getCache) {
+var HybridObserver = function (localCursor, remoteCursor, collectionOptions, options) {
   var self = this;
 
   this._initialized = false;
   this._localCursor = localCursor;
   this._remoteCursor = remoteCursor;
   this._options = options;
-  this._cacheCallback = cacheCallback;
-  this._getCache = getCache;
+  this._cacheCallback = options.cacheCallback;
+  this._getCache = options.getCache;
 
   this._localCache = [];
   this._remoteCache = [];
@@ -87,11 +85,11 @@ var HybridObserver = function (localCursor, remoteCursor, collectionOptions, opt
   var _refresh = _.throttle(this.refresh.bind(this), collectionOptions.throttleObserveRefresh);
 
   var remoteOptions = buildOptions(this._remoteCache, _refresh, this._removed, true);
-  if (!getCache) {
+  if (!this._getCache) {
     this._localHandle = this._localCursor.observe(buildOptions(this._localCache, _refresh, this._removed, false));
     this._remoteHandle = this._remoteCursor.observe(remoteOptions);
   } else {
-    getCache(function (err, data) {
+    this._getCache(function (err, data) {
       if (data) {
         self._remoteCache.concat(data);
         self.refresh();

--- a/lib/hybrid/store.js
+++ b/lib/hybrid/store.js
@@ -99,16 +99,7 @@ HybridStore.prototype._cleanCollection = function (
   propertyName
 ) {
   var comparisonPropertyName = propertyName || "_insertedAt";
-  collection
-    .find({ [comparisonPropertyName]: { $lt: maxEpoch } })
-    .toArray(function (err, documents) {
-      var documentIds = documents.map(function (document) {
-        return document.id;
-      });
-      collection.remove({ _id: { $in: documentIds } }, null, function () {
-        console.log({ clearedIds: documentIds });
-      });
-    });
+  collection.remove({ [comparisonPropertyName]: { $lt: maxEpoch } }, null, function () {});
 };
 
 module.exports = HybridStore;

--- a/lib/hybrid/store.js
+++ b/lib/hybrid/store.js
@@ -11,7 +11,8 @@ var defaultOptions = {
   cacheLifeTime: 2, // Time in minutes that the cache should be alive
   cacheQueries: false,
   localOnlyCollections: new Set(),
-  cacheCollectionName: '_cache'
+  cacheCollectionName: '_cache',
+  projectedDocumentsCollection: '_projected_cache'
 };
 
 var HybridStore = function (local, remote, options) {
@@ -24,6 +25,7 @@ var HybridStore = function (local, remote, options) {
     this._collections[this._options.cacheCollectionName] = local.collection(
       this._options.cacheCollectionName
     );
+    this._collections[this._options.projectedDocumentsCollection] = local.collection(this._options.projectedDocumentsCollection);
     setInterval(this._cleanCachedData.bind(this), 1000 * 60 * 30); // Clean every 30 minutes
   }
 };
@@ -57,7 +59,8 @@ HybridStore.prototype.collection = function (name, callback) {
         remote,
         name,
         this._options,
-        this._collections[this._options.cacheCollectionName]
+        this._collections[this._options.cacheCollectionName],
+        this._collections[this._options.projectedDocumentsCollection]
       );
     }
 

--- a/lib/hybrid/store.js
+++ b/lib/hybrid/store.js
@@ -2,12 +2,16 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var Collection = require('./collection');
 
+var CACHE_COLLECTION_NAME = 'cache';
 var defaultOptions = {
   syncWrites: false, // if local writes should be sent over the wire to remote
   cacheReads: true,  // when reading remote documents should they be stored in the local db
   localFirst: true,   // when reading documents should we return the locally cached ones first and then the remote ones when they arrive
   throwRemoteErr: false, // if remote throws should we swallow them or throw them to client
-  throttleObserveRefresh: 200
+  throttleObserveRefresh: 200,
+  cacheLifeTime: 5, // Time in minutes that the cache should be alive
+  cacheQueries: false,
+  localOnlyCollections: new Set(),
 };
 
 var HybridStore = function (local, remote, options) {
@@ -15,6 +19,13 @@ var HybridStore = function (local, remote, options) {
   this._remote = remote;
   this._options = _.defaults(options || {}, defaultOptions);
   this._collections = {};
+
+  if (this._options.cacheQueries) {
+    this._collections[CACHE_COLLECTION_NAME] = local.collection(
+      CACHE_COLLECTION_NAME
+    );
+    setInterval(this._cleanCachedData.bind(this), 1000 * 60 * 30); // Clean every 30 minutes
+  }
 };
 
 HybridStore.prototype.open = function () {
@@ -36,17 +47,68 @@ HybridStore.prototype.collection = function (name, callback) {
   var collection = this._collections[name];
   if (!collection) {
     var local = this._local.collection(name);
-    var remote = this._remote.collection(name);
-    collection = this._collections[name] = new Collection(
-      local
-      , remote
-      , name
-      , this._options);
+
+    if (this._options.localOnlyCollections.has(name)) {
+      this._collections[name] = local;
+    } else {
+      var remote = this._remote.collection(name);
+      this._collections[name] = new Collection(
+        local,
+        remote,
+        name,
+        this._options,
+        this._collections[CACHE_COLLECTION_NAME]
+      );
+    }
+
+    collection = this._collections[name];
   }
   if (callback) {
     callback(collection);
   }
   return collection;
+};
+
+HybridStore.prototype._cleanCachedData = function () {
+  var self = this;
+  var minimumChangeDateTime = new Date();
+  minimumChangeDateTime.setMinutes(
+    minimumChangeDateTime.getMinutes() - this._options.cacheLifeTime
+  );
+  var maxTimeEpoch = minimumChangeDateTime.getTime();
+
+  // Clean cached query first to prevent query not pointing at anything
+  this._cleanCollection(
+    this._collections[CACHE_COLLECTION_NAME],
+    maxTimeEpoch,
+    "createDateTime"
+  );
+
+  _.forEach(this._collections, function (collection, collectionName) {
+    if (collectionName === CACHE_COLLECTION_NAME) {
+      return;
+    }
+
+    self._cleanCollection(collection._local || collection, maxTimeEpoch);
+  });
+};
+
+HybridStore.prototype._cleanCollection = function (
+  collection,
+  maxEpoch,
+  propertyName
+) {
+  var comparisonPropertyName = propertyName || "_insertedAt";
+  collection
+    .find({ [comparisonPropertyName]: { $lt: maxEpoch } })
+    .toArray(function (err, documents) {
+      var documentIds = documents.map(function (document) {
+        return document.id;
+      });
+      collection.remove({ _id: { $in: documentIds } }, null, function () {
+        console.log({ clearedIds: documentIds });
+      });
+    });
 };
 
 module.exports = HybridStore;

--- a/lib/hybrid/store.js
+++ b/lib/hybrid/store.js
@@ -2,7 +2,6 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var Collection = require('./collection');
 
-var CACHE_COLLECTION_NAME = 'cache';
 var defaultOptions = {
   syncWrites: false, // if local writes should be sent over the wire to remote
   cacheReads: true,  // when reading remote documents should they be stored in the local db
@@ -12,6 +11,7 @@ var defaultOptions = {
   cacheLifeTime: 2, // Time in minutes that the cache should be alive
   cacheQueries: false,
   localOnlyCollections: new Set(),
+  cacheCollectionName: '_cache'
 };
 
 var HybridStore = function (local, remote, options) {
@@ -21,8 +21,8 @@ var HybridStore = function (local, remote, options) {
   this._collections = {};
 
   if (this._options.cacheQueries) {
-    this._collections[CACHE_COLLECTION_NAME] = local.collection(
-      CACHE_COLLECTION_NAME
+    this._collections[this._options.cacheCollectionName] = local.collection(
+      this._options.cacheCollectionName
     );
     setInterval(this._cleanCachedData.bind(this), 1000 * 60 * 30); // Clean every 30 minutes
   }
@@ -57,7 +57,7 @@ HybridStore.prototype.collection = function (name, callback) {
         remote,
         name,
         this._options,
-        this._collections[CACHE_COLLECTION_NAME]
+        this._collections[this._options.cacheCollectionName]
       );
     }
 
@@ -79,13 +79,13 @@ HybridStore.prototype._cleanCachedData = function () {
 
   // Clean cached query first to prevent query not pointing at anything
   this._cleanCollection(
-    this._collections[CACHE_COLLECTION_NAME],
+    this._collections[this._options.cacheCollectionName],
     maxTimeEpoch,
     "createDateTime"
   );
 
   _.forEach(this._collections, function (collection, collectionName) {
-    if (collectionName === CACHE_COLLECTION_NAME) {
+    if (collectionName === self._options.cacheCollectionName) {
       return;
     }
 

--- a/lib/hybrid/store.js
+++ b/lib/hybrid/store.js
@@ -9,7 +9,7 @@ var defaultOptions = {
   localFirst: true,   // when reading documents should we return the locally cached ones first and then the remote ones when they arrive
   throwRemoteErr: false, // if remote throws should we swallow them or throw them to client
   throttleObserveRefresh: 200,
-  cacheLifeTime: 5, // Time in minutes that the cache should be alive
+  cacheLifeTime: 2, // Time in minutes that the cache should be alive
   cacheQueries: false,
   localOnlyCollections: new Set(),
 };

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -96,9 +96,9 @@ var ViewDbSocketServer = function (viewdb, socket, queryDecorator, globalLimit, 
         if (_.isNumber(request.p.skip)) {
           cursor.skip(request.p.skip);
         }
-        var observeHandle = cursor.observe({
+        var observeOptions = {
           init: function (result) {
-            sendChange(socket, { i: { r: result }}, request);
+            sendChange(socket, { i: { r: result } }, request);
           },
           added: function (e, index) {
             sendChange(socket, { a: { e: e, i: index } }, request);
@@ -113,7 +113,31 @@ var ViewDbSocketServer = function (viewdb, socket, queryDecorator, globalLimit, 
             sendChange(socket, { m: { e: e, o: oldIndex, n: newIndex } }, request);
           },
           oplog: true
-        });
+        };
+
+        if (request.p.events) {
+          if (!request.p.events.i) {
+            delete observeOptions.init;
+          }
+
+          if (!request.p.events.a) {
+            delete observeOptions.added;
+          }
+
+          if (!request.p.events.r) {
+            delete observeOptions.removed;
+          }
+
+          if (!request.p.events.c) {
+            delete observeOptions.changed;
+          }
+
+          if (!request.p.events.m) {
+            delete observeOptions.moved;
+          }
+        }
+
+        var observeHandle = cursor.observe(observeOptions);
         _observers[observeId] = {
           i: request.i
           , handle: observeHandle

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -96,6 +96,9 @@ var ViewDbSocketServer = function (viewdb, socket, queryDecorator, globalLimit, 
         if (_.isNumber(request.p.skip)) {
           cursor.skip(request.p.skip);
         }
+        if (request.p.project) {
+          cursor.project(request.p.project);
+        }
         var observeHandle = cursor.observe({
           init: function (result) {
             sendChange(socket, { i: { r: result }}, request);

--- a/package-lock.json
+++ b/package-lock.json
@@ -937,6 +937,11 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "viewdb_persistence_store_remote",
-  "version": "2.2.20",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.30",
+    "crypto-js": "^4.1.1",
     "debug": "^2.2.0",
     "eslint": "^2.5.3",
     "eslint-config-surikat": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewdb_persistence_store_remote",
-  "version": "2.2.20",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/hybrid/store.js
+++ b/test/hybrid/store.js
@@ -1,0 +1,60 @@
+var Store = require('../../lib/hybrid/store');
+var LocalStore = require('viewdb/lib/inmemory/store');
+var should = require('should');
+var Cursor = require('viewdb/lib').Cursor;
+
+describe('Store', function () {
+  it('should cache', function (done) {
+    var localStore = new LocalStore();
+    var remoteStore = new LocalStore();
+
+    remoteStore.collection('alfa').insert({ id: 'abc' }, function() {
+      var hcursor = new Store(localStore, remoteStore, { cacheQueries: true });
+      hcursor.collection('alfa').find({}).toArray(function (err, res) {
+        if (res.length > 0) {
+          // Caching of data is not sync action, wait for next tick before fetching data
+          setTimeout(function () {
+            hcursor.collection('alfa')._getCachedData({}, undefined, undefined, undefined, undefined, function (err, data) {
+              data.length.should.equal(1);
+              done();
+            });
+          });
+        }
+      });
+    });
+  });
+
+  it('should cache projected data separate', function (done) {
+    Cursor.prototype.project = function (project) {
+      this._project = project;
+      return this;
+    };
+    var localStore = new LocalStore();
+    var remoteStore = new LocalStore();
+
+    remoteStore.collection('alfa').insert({ id: 'abc', property: 'def' }, function() {
+      var hcursor = new Store(localStore, remoteStore, { cacheQueries: true });
+      hcursor.collection('alfa').find({ id: 'abc' }).project({ id: 1 }).toArray(function (err, res) {
+        if (res.length > 0) {
+          // Caching of data is not sync action, wait for next tick before fetching data
+          setTimeout(function () {
+            hcursor.collection('alfa').find({ id: 'abc' }).toArray(function (err2, projectedRes) {
+              if (projectedRes.length > 0) {
+                setTimeout(function () {
+                  hcursor.collection('alfa')._getCachedData({ id: 'abc' }, undefined, undefined, undefined, undefined, function (_err, data) {
+                    hcursor.collection('alfa')._getCachedData({ id: 'abc' }, undefined, undefined, undefined, { id: 1 }, function (_err2, projectedData) {
+                      data.length.should.equal(1);
+                      projectedData.length.should.equal(1);
+                      projectedData[0]._insertedAt.should.be.below(data[0]._insertedAt);
+                      done();
+                    });
+                  });
+                });
+              }
+            });
+          });
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds Caching of data for find and observe
- Find: If data is present in the cache it will not fetch from remote. If no data is present it will fetch from remote and cache the result to local.
- Observe: If data is present in cache on startup, it will not fetch initial data. When observe updates with new data it will be saved to the cache. The data for an active observe will be "touched" once in a while so the cache life time does not run out.

Caching is done by saving a hashed version of the query, limit, skip, sort parameters as a key and having a result set which contains the ids of the resulting documents.
The new dependency `crypto-js` is used to create said hash.

Clearing of the cache is done in two steps to not update indexeddb more than needed. When fetching data from cache only data that has not expired will be returned. Then every 30 minutes a hard delete will be performed were data will be removed from indexeddb if the data has expired.

