### PR TITLE
avoid spurious refresh when sorting non-observed remote cursors

### DIFF
--- a/__tests__/remote/cursor.js
+++ b/__tests__/remote/cursor.js
@@ -39,6 +39,17 @@ describe('Remote server/client', function () {
         done();
       });
   });
+  it('#remote cursor sort should not trigger refresh when not observing', function () {
+    var collection = clientVdb.collection('dollhouse');
+    var changes = 0;
+    collection.on('change', function () {
+      changes++;
+    });
+
+    collection.find({ _id: 'echo' }).sort({ _id: 1 });
+
+    changes.should.equal(0);
+  });
   it('#remote cursor count', function (done) {
     remote.collection('dollhouse').insert({ _id: 'echo' });
     remote.collection('dollhouse').insert({ _id: 'echo2' });

--- a/lib/client/cursor.js
+++ b/lib/client/cursor.js
@@ -56,7 +56,9 @@ RemoteCursor.prototype.project = function (params) {
 };
 
 RemoteCursor.prototype._refresh = function () {
-  this._collection.emit('change');
+  if (this._isObserving) {
+    this._collection.emit('change');
+  }
 };
 
 RemoteCursor.prototype.observe = function (options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viewdb_persistence_store_remote",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "viewdb_persistence_store_remote",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",
@@ -3536,6 +3536,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewdb_persistence_store_remote",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
RemoteCursor.sort() called _refresh() unconditionally, which emitted a collection-level
`change` event even when the cursor was not being observed. That could restart unrelated
observers on the same collection as a side effect of building a normal sorted query.
